### PR TITLE
insert empty grob and throw warning for invalid paths

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: ggpath
 Title: Robust Image Rendering Support for 'ggplot2'
-Version: 1.0.1
+Version: 1.0.1.9000
 Authors@R: 
     person("Sebastian", "Carl", , "mrcaseb@gmail.com", role = c("aut", "cre", "cph"))
 Description: A 'ggplot2' extension that enables robust image grobs in

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# ggpath (development version)
+
+* Invalid paths no longer result in an error. Instead, ggpath will warn the user and insert an empty grob.
+
 # ggpath 1.0.1
 
 * Fixed a test that was failing on some operating systems.

--- a/R/build_grobs.R
+++ b/R/build_grobs.R
@@ -4,7 +4,24 @@ build_grobs <- function(i, alpha, colour, path, data,
                         call = rlang::caller_env()) {
   img <- try(reader_function(path[i]), silent = TRUE)
 
-  if (inherits(img, "try-error")) cli::cli_abort(img, call = call)
+  # if the path is invalid we warn the user and insert a NULL grob
+  if (inherits(img, "try-error")) {
+    cli::cli_warn(
+      "{.pkg ggpath} failed to read an image from {.path {path[i]}}. \\
+      It will insert an empty grob instead. Here is the \\
+      error message: {img}"
+    )
+
+    return({
+      grid::nullGrob(
+        name = paste0("ggpath.grob.", i),
+        vp = grid::viewport(
+          x = grid::unit(data$x[i], "native"),
+          y = grid::unit(data$y[i], "native")
+        )
+      )
+    })
+  }
 
   if (is.null(alpha)) { # no alpha requested
     modified_img <- resolve_img_color(img = img, col = colour[i])

--- a/tests/testthat/test-geom_from_path.R
+++ b/tests/testthat/test-geom_from_path.R
@@ -28,15 +28,18 @@ test_that("geom from path works", {
     coord_cartesian(xlim = c(-2, 2)) +
     theme_minimal()
 
-  # bad path error
-  p4 <- ggplot(plot_data, aes(x = x, y = y)) +
+  # create data frame with x-y-coordinates and the above local path
+  # to check the warning. Need separate data set because testthat::expect_warning
+  # does not catch multiple warnings
+  plot_data_warning <- data.frame(x = 1, y = 1, path = local_image_path)
+  p4 <- ggplot(plot_data_warning, aes(x = x, y = y)) +
     geom_from_path(aes(path = paste0(path, "g")), width = 0.2, alpha = -1) +
     coord_cartesian(xlim = c(-2, 2)) +
     theme_minimal()
 
   expect_error(print(p2), regexp = 'all values of `alpha` have to be in range')
   expect_error(print(p3), regexp = 'all values of `alpha` have to be in range')
-  expect_error(print(p4))
+  expect_warning(print(p4))
 
   # It seems like vdiffr isn't handling cran = FALSE properly so I call
   # skip_on_cran() explicitly


### PR DESCRIPTION
try to adapt geom_point's behavior which doesn't error on NA coordinates.

So now ggpath doesn't error on bad paths, instead it warns the user and inserts a NULL grob 