### PR TITLE
drop ggplot2 downwards compatibility

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: ggpath
 Title: Robust Image Rendering Support for 'ggplot2'
-Version: 1.0.2.9001
+Version: 1.0.2.9002
 Authors@R: 
     person("Sebastian", "Carl", , "mrcaseb@gmail.com", role = c("aut", "cre", "cph"))
 Description: A 'ggplot2' extension that enables robust image grobs in

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,12 @@
 # ggpath (development version)
 
+ggpath now requires ggplot2 v4! This package is intended to be a ggplot2 extension 
+and if ggplot2 version jumps make breaking changes, then it's best for the extension 
+to not try to be downwards compatible.
+
 * ggpath now requires R 4.1 because magick needs this R version. This also follows the [Tidyverse R version support rules](https://www.tidyverse.org/blog/2019/04/r-version-support/). (#14)
 * rewrite theme elements in S7 to fully work with ggplot2 v4.0. (#16)
+* remove ggplot2 downwards compatibility in `size` argument of `geom_*_lines()` functions as ggpath now requires ggplot2 v4.
 
 # ggpath 1.0.2
 

--- a/R/geom_lines.R
+++ b/R/geom_lines.R
@@ -18,8 +18,7 @@
 #'   \item{`alpha = NA`}{The alpha channel, i.e. transparency level, as a numerical value between 0 and 1.}
 #'   \item{`color = "red"`}{The color of the drawn lines.}
 #'   \item{`linetype = 2`}{The linetype of the drawn lines.}
-#'   \item{`size = 0.5`}{The size of the drawn lines. Deprecated as of ggplot2 v3.4.0, use `linewidth` instead.}
-#'   \item{`linewidth = 0.5`}{The width of the drawn lines. Starting at ggplot2 v3.4.0.}
+#'   \item{`linewidth = 0.5`}{The width of the drawn lines.}
 #' }
 #' @seealso The underlying ggplot2 geoms [ggplot2::geom_hline()] and [ggplot2::geom_vline()]
 #' @name geom_lines
@@ -119,33 +118,25 @@ GeomRefLines <- ggplot2::ggproto("GeomRefLines", ggplot2::Geom,
 
     # Can't do anything if either of y0 and x0 are aesthetics
     if (all(!c("x0", "y0") %in% args)) {
-      cli::cli_abort("{.var geom_median_lines()} and {.var geom_mean_lines()} \\
+      cli::cli_abort("{.fun geom_median_lines} and {.fun geom_mean_lines} \\
                      require at least one of the following aesthetics: \\
                      {.var x0}, {.var y0}")
     }
 
-    if (any(args == "size") && is_ggplot_340()){
+    if (any(args == "size")){
       cli::cli_warn(
-        "The {.arg size} aesthetic has been deprecated as of ggplot2 v3.4.0! \\
-        Please use {.arg linewidth} in the future. \\
+        "The {.arg size} aesthetic for lines has been deprecated as of \\
+        ggplot2 v3.4.0! Please use {.arg linewidth} in the future. \\
         Will proceed with {.arg linewidth = size}"
       )
       data$linewidth <- data$size
     }
 
-    if(!is_ggplot_340()) data$size <- data$linewidth
-
     # Since y0 and x0 can be in data, it is necessary to select only
     # those variables that are required for the underlying Geoms to work.
     # This could also be achieved by setting inherit.aes to FALSE explicitly but
     # I want to be able to inherit aesthetics so I had to do this differently.
-    # We also need to distinguish in the ggplot2 version because the "size"
-    # argument has been replaced by "linewidth" in v3.4.0.
-    relevant_columns <- if(is_ggplot_340()){
-      c("PANEL", "group", "colour", "linewidth", "linetype", "alpha")
-    } else{
-      c("PANEL", "group", "colour", "size", "linetype", "alpha")
-    }
+    relevant_columns <- c("PANEL", "group", "colour", "linewidth", "linetype", "alpha")
 
     # if x0 and/or y0 are present in data we have to compute the relevant
     # xintercept and yintercept variables and drop anything irrelevant from data
@@ -178,5 +169,3 @@ GeomRefLines <- ggplot2::ggproto("GeomRefLines", ggplot2::Geom,
 
   draw_key = ggplot2::draw_key_path
 )
-
-is_ggplot_340 <- function() utils::packageVersion("ggplot2") >= "3.4.0"

--- a/man/geom_lines.Rd
+++ b/man/geom_lines.Rd
@@ -104,8 +104,7 @@ aesthetics (at least one of the \code{x0} or \code{y0} aesthetics is required):
 \item{\code{alpha = NA}}{The alpha channel, i.e. transparency level, as a numerical value between 0 and 1.}
 \item{\code{color = "red"}}{The color of the drawn lines.}
 \item{\code{linetype = 2}}{The linetype of the drawn lines.}
-\item{\code{size = 0.5}}{The size of the drawn lines. Deprecated as of ggplot2 v3.4.0, use \code{linewidth} instead.}
-\item{\code{linewidth = 0.5}}{The width of the drawn lines. Starting at ggplot2 v3.4.0.}
+\item{\code{linewidth = 0.5}}{The width of the drawn lines.}
 }
 }
 


### PR DESCRIPTION
ggpath now requires ggplot2 v4! This package is intended to be a ggplot2 extension and if ggplot2 version jumps make breaking changes, then it's best for the extension to not try to be downwards compatible.